### PR TITLE
Include Linux bestiary fix until patched upstream

### DIFF
--- a/amcdata-linux-bestiary-fix.patch
+++ b/amcdata-linux-bestiary-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/CODE/BESTIARY_DEFS.CON b/CODE/BESTIARY_DEFS.CON
+index 1105f01..155cab9 100644
+--- a/CODE/BESTIARY_DEFS.CON
++++ b/CODE/BESTIARY_DEFS.CON
+@@ -69,7 +69,7 @@ ends
+ defstate bst_check_hasdef
+ 	// if string 1380 is not an empty string then we had a def
+ 	qstrcmp 1380 1399 bst_hasdef
+-	abs bst_hasdef
++	ifn bst_hasdef 0 set bst_hasdef 1
+ ends
+ 
+ defstate bst_cycloid_defs

--- a/io.itch.amcsquad.amcsquad.yml
+++ b/io.itch.amcsquad.amcsquad.yml
@@ -32,13 +32,17 @@ modules:
               version-query: $tag | sub(\"^[vV]\"; \"\")
               is-main-source: true
               url-template: https://gitlab.com/fpiesche/amc-squad-data/-/archive/v$version/amc-squad-data-v$version.tar.bz2
+          # Fix bestiary on Linux
+          - type: patch
+            path: amcdata-linux-bestiary-fix.patch
         build-commands:
           - desktop-file-edit --set-key="Exec" --set-value="io.itch.amcsquad.amcsquad.sh" meta/io.itch.amcsquad.amcsquad.desktop
           - desktop-file-edit --set-key="Exec" --set-value="io.itch.amcsquad.mapster32.sh" meta/io.itch.amcsquad.mapster32.desktop
+          - desktop-file-edit --set-key="Icon" --set-value="io.itch.amcsquad.amcsquad.mapster32" meta/io.itch.amcsquad.mapster32.desktop
           - install -Dm 644 meta/io.itch.amcsquad.amcsquad.desktop -t /app/share/applications
-          - install -Dm 644 meta/io.itch.amcsquad.mapster32.desktop -t /app/share/applications
+          - install -Dm 644 meta/io.itch.amcsquad.mapster32.desktop -T /app/share/applications/io.itch.amcsquad.amcsquad.mapster32.desktop
           - install -Dm 644 meta/io.itch.amcsquad.amcsquad.png -t /app/share/icons/hicolor/256x256/apps
-          - install -Dm 644 meta/io.itch.amcsquad.mapster32.png -t /app/share/icons/hicolor/256x256/apps
+          - install -Dm 644 meta/io.itch.amcsquad.mapster32.png -T /app/share/icons/hicolor/256x256/apps/io.itch.amcsquad.amcsquad.mapster32.png
           - install -Dm 644 meta/io.itch.amcsquad.amcsquad.metainfo.xml -t /app/share/metainfo
           - install -Dm 644 meta/io.itch.amcsquad.amcsquad.releases.xml -t /app/share/metainfo/releases
           - rm -rf meta


### PR DESCRIPTION
Also fixes creation of the shortcut for mapster32.