### PR TITLE
Move game data to extra-data

### DIFF
--- a/io.itch.amcsquad.amcsquad.yml
+++ b/io.itch.amcsquad.amcsquad.yml
@@ -1,6 +1,6 @@
 app-id: io.itch.amcsquad.amcsquad
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: "24.08"
 sdk: org.freedesktop.Sdk
 command: io.itch.amcsquad.amcsquad.sh
 
@@ -17,37 +17,70 @@ modules:
   - name: amcduke32
     modules:
       - shared-modules/glu/glu-9.json
-      - name: amc-data
+      - name: amc-meta
         buildsystem: simple
         sources:
-          - type: archive
-            url: https://gitlab.com/fpiesche/amc-squad-data/-/archive/v4.5.2/amc-squad-data-v4.5.2.tar.bz2
-            sha256: 8f34ac685f4f63e0f3756670d1ea3104e818398532f3960ead8c0cf71653a06e
+          - type: file
+            url: https://gitlab.com/fpiesche/amc-squad-data/-/raw/v4.5.2/meta/io.itch.amcsquad.amcsquad.desktop
+            sha256: 31ade046025405160d9f1a17ddf62f24b3b09e841b74bd969f2795d77aa2759a
             x-checker-data:
               type: json
               url: https://gitlab.com/api/v4/projects/fpiesche%2Famc-squad-data/repository/tags
-              tag-query: first | .name
-              commit-query: first | .commit.id
-              timestamp-query: first | .commit.committed_date
               version-query: $tag | sub(\"^[vV]\"; \"\")
-              is-main-source: true
-              url-template: https://gitlab.com/fpiesche/amc-squad-data/-/archive/v$version/amc-squad-data-v$version.tar.bz2
+              url-template: https://gitlab.com/fpiesche/amc-squad-data/-/raw/v$version/meta/io.itch.amcsquad.amcsquad.desktop
+          - type: file
+            url: https://gitlab.com/fpiesche/amc-squad-data/-/raw/v4.5.2/meta/io.itch.amcsquad.amcsquad.png
+            sha256: e5ca3c8926e652450df011838af98d4c4cc0e915e3d3dd1c59ba41985e76459e
+            x-checker-data:
+              type: json
+              url: https://gitlab.com/api/v4/projects/fpiesche%2Famc-squad-data/repository/tags
+              version-query: $tag | sub(\"^[vV]\"; \"\")
+              url-template: https://gitlab.com/fpiesche/amc-squad-data/-/raw/v$version/meta/io.itch.amcsquad.amcsquad.png
+          - type: file
+            url: https://gitlab.com/fpiesche/amc-squad-data/-/raw/v4.5.2/meta/io.itch.amcsquad.mapster32.desktop
+            sha256: 032c568bdab1f1067c60272ecfcac794caa823ea677748115fba75a2731d331f
+            x-checker-data:
+              type: json
+              url: https://gitlab.com/api/v4/projects/fpiesche%2Famc-squad-data/repository/tags
+              version-query: $tag | sub(\"^[vV]\"; \"\")
+              url-template: https://gitlab.com/fpiesche/amc-squad-data/-/raw/v$version/meta/io.itch.amcsquad.mapster32.desktop
+          - type: file
+            url: https://gitlab.com/fpiesche/amc-squad-data/-/raw/v4.5.2/meta/io.itch.amcsquad.mapster32.png
+            sha256: dcdaf7f9b504b2be2578f15e6f4fbf0791acf256b09aac40dfa8266e3a61ed84
+            x-checker-data:
+              type: json
+              url: https://gitlab.com/api/v4/projects/fpiesche%2Famc-squad-data/repository/tags
+              version-query: $tag | sub(\"^[vV]\"; \"\")
+              url-template: https://gitlab.com/fpiesche/amc-squad-data/-/raw/v$version/meta/io.itch.amcsquad.mapster32.png
+          - type: file
+            url: https://gitlab.com/fpiesche/amc-squad-data/-/raw/v4.5.2/meta/io.itch.amcsquad.amcsquad.metainfo.xml
+            sha256: a056308806104a84b5092d343b5c8806534bb057a840298ff954e051aa5ebf4f
+            x-checker-data:
+              type: json
+              url: https://gitlab.com/api/v4/projects/fpiesche%2Famc-squad-data/repository/tags
+              version-query: $tag | sub(\"^[vV]\"; \"\")
+              url-template: https://gitlab.com/fpiesche/amc-squad-data/-/raw/v$version/meta/io.itch.amcsquad.amcsquad.metainfo.xml
+          - type: file
+            url: https://gitlab.com/fpiesche/amc-squad-data/-/raw/v4.5.2/meta/io.itch.amcsquad.amcsquad.releases.xml
+            sha256: d4598f05c5b32d01bd4f684b6f0fbcd21ab7b416513d52bada8e76388ad61a6c
+            x-checker-data:
+              type: json
+              url: https://gitlab.com/api/v4/projects/fpiesche%2Famc-squad-data/repository/tags
+              version-query: $tag | sub(\"^[vV]\"; \"\")
+              url-template: https://gitlab.com/fpiesche/amc-squad-data/-/raw/v$version/meta/io.itch.amcsquad.amcsquad.releases.xml
         build-commands:
           - desktop-file-edit --set-key="Exec" --set-value="io.itch.amcsquad.amcsquad.sh"
-            meta/io.itch.amcsquad.amcsquad.desktop
+            io.itch.amcsquad.amcsquad.desktop
           - desktop-file-edit --set-key="Exec" --set-value="io.itch.amcsquad.mapster32.sh"
-            meta/io.itch.amcsquad.mapster32.desktop
+            io.itch.amcsquad.mapster32.desktop
           - desktop-file-edit --set-key="Icon" --set-value="io.itch.amcsquad.amcsquad.mapster32"
-            meta/io.itch.amcsquad.mapster32.desktop
-          - install -Dm 644 meta/io.itch.amcsquad.amcsquad.desktop -t /app/share/applications
-          - install -Dm 644 meta/io.itch.amcsquad.mapster32.desktop -T /app/share/applications/io.itch.amcsquad.amcsquad.mapster32.desktop
-          - install -Dm 644 meta/io.itch.amcsquad.amcsquad.png -t /app/share/icons/hicolor/256x256/apps
-          - install -Dm 644 meta/io.itch.amcsquad.mapster32.png -T /app/share/icons/hicolor/256x256/apps/io.itch.amcsquad.amcsquad.mapster32.png
-          - install -Dm 644 meta/io.itch.amcsquad.amcsquad.metainfo.xml -t /app/share/metainfo
-          - install -Dm 644 meta/io.itch.amcsquad.amcsquad.releases.xml -t /app/share/metainfo/releases
-          - rm -rf meta
-          - mkdir -p /app/bin
-          - cp -rv ./* /app/bin/
+            io.itch.amcsquad.mapster32.desktop
+          - install -Dm 644 io.itch.amcsquad.amcsquad.desktop -t /app/share/applications
+          - install -Dm 644 io.itch.amcsquad.mapster32.desktop -T /app/share/applications/io.itch.amcsquad.amcsquad.mapster32.desktop
+          - install -Dm 644 io.itch.amcsquad.amcsquad.png -t /app/share/icons/hicolor/256x256/apps
+          - install -Dm 644 io.itch.amcsquad.mapster32.png -T /app/share/icons/hicolor/256x256/apps/io.itch.amcsquad.amcsquad.mapster32.png
+          - install -Dm 644 io.itch.amcsquad.amcsquad.metainfo.xml -t /app/share/metainfo
+          - install -Dm 644 io.itch.amcsquad.amcsquad.releases.xml -t /app/share/metainfo/releases
     sources:
       - type: archive
         url: https://api.github.com/repos/dibollinger/amcduke32/zipball/4.5.0
@@ -96,13 +129,13 @@ modules:
       - type: script
         dest-filename: io.itch.amcsquad.amcsquad.sh
         commands:
-          - cd /app/bin
-          - ./amcsquad
+          - cd /app/extra/amcsquad
+          - amcsquad
       - type: script
         dest-filename: io.itch.amcsquad.mapster32.sh
         commands:
-          - cd /app/bin
-          - ./mapster32
+          - cd /app/extra/amcsquad
+          - mapster32
     buildsystem: simple
     builddir: true
     build-options:
@@ -113,3 +146,29 @@ modules:
       - install -Dm 755 mapster32 -t /app/bin
       - install -Dm 755 io.itch.amcsquad.amcsquad.sh -t /app/bin
       - install -Dm 755 io.itch.amcsquad.mapster32.sh -t /app/bin
+
+  - name: amc-data
+    buildsystem: simple
+    sources:
+      - type: extra-data
+        filename: amc-data.tar.bz2
+        url: https://gitlab.com/fpiesche/amc-squad-data/-/archive/v4.5.2/amc-squad-data-v4.5.2.tar.bz2
+        sha256: 8f34ac685f4f63e0f3756670d1ea3104e818398532f3960ead8c0cf71653a06e
+        size: 1099295887
+        x-checker-data:
+          type: json
+          url: https://gitlab.com/api/v4/projects/fpiesche%2Famc-squad-data/repository/tags
+          tag-query: first | .name
+          commit-query: first | .commit.id
+          timestamp-query: first | .commit.committed_date
+          version-query: $tag | sub(\"^[vV]\"; \"\")
+          is-main-source: true
+          url-template: https://gitlab.com/fpiesche/amc-squad-data/-/archive/v$version/amc-squad-data-v$version.tar.bz2
+      - type: script
+        dest-filename: apply_extra
+        commands:
+          - mkdir -p /app/extra/amcsquad
+          - tar xf amc-data.tar.bz2 --strip-components=1 --directory=/app/extra/amcsquad && rm amc-data.tar.bz2
+    build-commands:
+      - mkdir -p /app/bin
+      - cp -rv ./* /app/bin/


### PR DESCRIPTION
This should massively reduce the build time and will save about 1GB of space on the flathub repo, now that I've actually figured out how to use `extra-data`.

Also update runtime to 24.08 while I'm in here.